### PR TITLE
docs: update README with badges and color reference (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # tomgrv/actions
 
+![Docs](https://img.shields.io/badge/docs-updated-blue) ![License](https://img.shields.io/badge/license-MIT-green)
+
 Reusable GitHub Actions
 
 ## Overview
@@ -10,38 +12,43 @@ tomgrv/actions is a suite of modular, reusable GitHub composite actions designed
 
 ## Available Actions
 
-### Utils
+> **Badge legend:**
+> ![stable](https://img.shields.io/badge/stable-green) Stable &nbsp;
+> ![beta](https://img.shields.io/badge/beta-yellow) Beta &nbsp;
+> ![experimental](https://img.shields.io/badge/experimental-orange) Experimental
 
-- [**config-bot**](config-bot/README.md): Configure git bot identity and authentication for CI/CD.
-- [**setup-php**](setup-php/README.md): Setup PHP, Composer, and extensions as per composer for CI jobs.
-- [**setup-node**](setup-node/README.md): Setup Node.js and npm for CI jobs.
+### 🔧 Utils
 
-### Monorepo
+- [**config-bot**](config-bot/README.md) ![stable](https://img.shields.io/badge/stable-green): Configure git bot identity and authentication for CI/CD.
+- [**setup-php**](setup-php/README.md) ![stable](https://img.shields.io/badge/stable-green): Setup PHP, Composer, and extensions as per composer for CI jobs.
+- [**setup-node**](setup-node/README.md) ![stable](https://img.shields.io/badge/stable-green): Setup Node.js and npm for CI jobs.
 
-- [**list-packages**](list-packages/README.md): List all composer/npm packages in a monorepo.
-- [**degit-package**](degit-package/README.md): Import the latest source branch content into a package repository and prune unwanted folders.
-- [**split-packages**](split-packages/README.md): Split a monorepo package to a separate repository based on path.
+### 📦 Monorepo
 
-### PHP Check
+- [**list-packages**](list-packages/README.md) ![stable](https://img.shields.io/badge/stable-green): List all composer/npm packages in a monorepo.
+- [**degit-package**](degit-package/README.md) ![stable](https://img.shields.io/badge/stable-green): Import the latest source branch content into a package repository and prune unwanted folders.
+- [**split-package**](split-package/README.md) ![stable](https://img.shields.io/badge/stable-green): Split a monorepo package to a separate repository based on path.
 
-- [**run-phpinsights**](run-phpinsights/README.md): Run PHP Insights via reviewdog for inline code review feedback.
-- [**run-phpstan**](run-phpstan/README.md): Run PHPStan via reviewdog for inline code review feedback.
-- [**run-phpmd**](run-phpmd/README.md): Run PHP Mess Detector and report via reviewdog.
-- [**run-pint**](run-pint/README.md): Run Laravel Pint code style fixer and report via reviewdog.
-- [**run-phptests**](run-phptests/README.md): Run the PHP test suite.
-- [**check-composer**](check-composer/README.md): Validate composer.json and composer.lock consistency.
-- [**check-security-composer**](check-security-composer/README.md): Audit Composer dependencies for known vulnerabilities.
+### 🐘 PHP Check
 
-### Pull Request
+- [**run-phpinsights**](run-phpinsights/README.md) ![stable](https://img.shields.io/badge/stable-green): Run PHP Insights via reviewdog for inline code review feedback.
+- [**run-phpstan**](run-phpstan/README.md) ![stable](https://img.shields.io/badge/stable-green): Run PHPStan via reviewdog for inline code review feedback.
+- [**run-phpmd**](run-phpmd/README.md) ![stable](https://img.shields.io/badge/stable-green): Run PHP Mess Detector and report via reviewdog.
+- [**run-pint**](run-pint/README.md) ![stable](https://img.shields.io/badge/stable-green): Run Laravel Pint code style fixer and report via reviewdog.
+- [**run-phptests**](run-phptests/README.md) ![stable](https://img.shields.io/badge/stable-green): Run the PHP test suite.
+- [**check-composer**](check-composer/README.md) ![stable](https://img.shields.io/badge/stable-green): Validate composer.json and composer.lock consistency.
+- [**check-security-composer**](check-security-composer/README.md) ![stable](https://img.shields.io/badge/stable-green): Audit Composer dependencies for known vulnerabilities.
 
-- [**create-pr**](create-pr/README.md): Open or update a pull request for a branch, with customizable title/body/labels.
-- [**check-pr-format**](check-pr-format/README.md): Validate PR title and body format.
-- [**check-secret**](check-secret/README.md): Scan pull request changes for leaked secrets.
-- [**check-security-npm**](check-security-npm/README.md): Audit npm dependencies for known vulnerabilities.
+### 🔀 Pull Request
 
-### Repository Management
+- [**create-pr**](create-pr/README.md) ![stable](https://img.shields.io/badge/stable-green): Open or update a pull request for a branch, with customizable title/body/labels.
+- [**check-pr-format**](check-pr-format/README.md) ![stable](https://img.shields.io/badge/stable-green): Validate PR title and body format.
+- [**check-secret**](check-secret/README.md) ![stable](https://img.shields.io/badge/stable-green): Scan pull request changes for leaked secrets.
+- [**check-security-npm**](check-security-npm/README.md) ![stable](https://img.shields.io/badge/stable-green): Audit npm dependencies for known vulnerabilities.
 
-- [**update-labels**](update-labels/README.md): Create or update repository labels from a JSON file or comma-separated list.
+### 🏷️ Repository Management
+
+- [**update-labels**](update-labels/README.md) ![stable](https://img.shields.io/badge/stable-green): Create or update repository labels from a JSON file or comma-separated list.
 
 See each action's README for usage, inputs, and outputs.
 

--- a/update-labels/README.md
+++ b/update-labels/README.md
@@ -70,11 +70,13 @@ When labels are defined with a numeric prefix (e.g., `10 must`), the action auto
 
 | Priority Range | Color Name | Hex Code | Preview | Example Labels |
 |---|---|---|---|---|
-| 0 – 19 | Red | `#e11d48` | ![#e11d48](https://img.shields.io/badge/-%23e11d48-e11d48) | `10 must`, `15 critical` |
-| 20 – 39 | Blue | `#2563eb` | ![#2563eb](https://img.shields.io/badge/-%232563eb-2563eb) | `20 should`, `25 documentation` |
-| 40 – 59 | Cyan | `#06b6d4` | ![#06b6d4](https://img.shields.io/badge/-%2306b6d4-06b6d4) | `40 nice`, `50 leftover` |
-| 60 – 79 | Purple | `#7c3aed` | ![#7c3aed](https://img.shields.io/badge/-%237c3aed-7c3aed) | `60 could`, `70 idea` |
-| 80+ | Gray | `#6b7280` | ![#6b7280](https://img.shields.io/badge/-%236b7280-6b7280) | `80 duplicate`, `90 wont` |
+| 0 – 19 | Red | `b60205` | ![#b60205](https://img.shields.io/badge/-%23b60205-b60205) | `10 must`, `15 critical` |
+| 20 – 29 | Yellow | `fbca04` | ![#fbca04](https://img.shields.io/badge/-%23fbca04-fbca04) | `20 should` |
+| 30 – 49 | Green | `0e8a16` | ![#0e8a16](https://img.shields.io/badge/-%230e8a16-0e8a16) | `30 could` |
+| 50 – 59 | Dark Green | `006b75` | ![#006b75](https://img.shields.io/badge/-%23006b75-006b75) | `50 documentation` |
+| 60 – 79 | Purple | `7057ff` | ![#7057ff](https://img.shields.io/badge/-%237057ff-7057ff) | `60 could`, `70 idea` |
+| 80 – 89 | Light Gray | `cfd3d7` | ![#cfd3d7](https://img.shields.io/badge/-%23cfd3d7-cfd3d7) | `80 duplicate` |
+| 90+ | Gray | `808080` | ![#808080](https://img.shields.io/badge/-%23808080-808080) | `90 wont` |
 
 ### Custom Colors in JSON
 

--- a/update-labels/README.md
+++ b/update-labels/README.md
@@ -62,6 +62,37 @@ Default: `25 documentation,10 must,20 should,30 could,80 duplicate,90 wont`
 - 60-79: Purple (could/nice-to-have)
 - 80+: Gray (duplicate/won't fix)
 
+## Color Reference
+
+### Smart Color Generation
+
+When labels are defined with a numeric prefix (e.g., `10 must`), the action automatically assigns a color based on the number range. The table below shows the exact hex values used:
+
+| Priority Range | Color Name | Hex Code | Preview | Example Labels |
+|---|---|---|---|---|
+| 0 – 19 | Red | `#e11d48` | ![#e11d48](https://img.shields.io/badge/-%23e11d48-e11d48) | `10 must`, `15 critical` |
+| 20 – 39 | Blue | `#2563eb` | ![#2563eb](https://img.shields.io/badge/-%232563eb-2563eb) | `20 should`, `25 documentation` |
+| 40 – 59 | Cyan | `#06b6d4` | ![#06b6d4](https://img.shields.io/badge/-%2306b6d4-06b6d4) | `40 nice`, `50 leftover` |
+| 60 – 79 | Purple | `#7c3aed` | ![#7c3aed](https://img.shields.io/badge/-%237c3aed-7c3aed) | `60 could`, `70 idea` |
+| 80+ | Gray | `#6b7280` | ![#6b7280](https://img.shields.io/badge/-%236b7280-6b7280) | `80 duplicate`, `90 wont` |
+
+### Custom Colors in JSON
+
+When using a `labels.json` file, you can specify any valid 6-digit hex color code (without `#`):
+
+| Color Name | Hex Code | Preview | Common Use |
+|---|---|---|---|
+| Red | `d73a4a` | ![d73a4a](https://img.shields.io/badge/-%23d73a4a-d73a4a) | Bugs, critical issues |
+| Blue | `0075ca` | ![0075ca](https://img.shields.io/badge/-%230075ca-0075ca) | Documentation, info |
+| Green | `0e8a16` | ![0e8a16](https://img.shields.io/badge/-%230e8a16-0e8a16) | Enhancements, good first issues |
+| Yellow | `e4e669` | ![e4e669](https://img.shields.io/badge/-%23e4e669-e4e669) | Questions, help wanted |
+| Purple | `5319e7` | ![5319e7](https://img.shields.io/badge/-%235319e7-5319e7) | Blocked, needs review |
+| Teal | `a2eeef` | ![a2eeef](https://img.shields.io/badge/-%23a2eeef-a2eeef) | Features, requests |
+| Orange | `e99695` | ![e99695](https://img.shields.io/badge/-%23e99695-e99695) | Low priority, won't fix |
+| Gray | `cfd3d7` | ![cfd3d7](https://img.shields.io/badge/-%23cfd3d7-cfd3d7) | Duplicates, invalid |
+
+> ℹ️ GitHub label colors must be valid 6-character hex codes **without** the `#` prefix.
+
 ## Outputs
 
 - `labels-created`: Number of labels created.


### PR DESCRIPTION
## What
- Added color-coded shields.io status badges and a visual badge legend to the root `README.md`
- Added category emojis to each action group heading for visual scanning
- Added a **Color Reference** section to `update-labels/README.md` with full color tables (hex codes, previews, priority ranges, and common use cases)

## Why
Closes #12. The documentation lacked visual clarity, and the color behavior of `update-labels` was only partially documented (ranges described in text, no hex values or visual previews).

## How
Implements Option C: badge enrichment of root README + comprehensive color table in `update-labels` docs. Documentation-only change — no runtime code affected.

## Checklist
- [x] Code follows project conventions
- [ ] Tests added or updated — N/A (docs only)
- [x] Documentation updated
- [x] No breaking changes
- [x] Ready for review