### PR TITLE
feat: add detect-changes composite action (#18)

### DIFF
--- a/detect-changes/README.md
+++ b/detect-changes/README.md
@@ -1,0 +1,64 @@
+<!-- @format -->
+
+# GitHub Action: Detect Changes
+
+Detects uncommitted or untracked changes in a given path using `git status --porcelain`.
+Outputs a `has-changes` flag that downstream steps can act on.
+
+## Inputs
+
+### path
+
+**Optional.** Base path to check for changes, relative to the repository root. Defaults to `.` (entire repo).
+
+### subpath
+
+**Optional.** Sub-path appended to `path` to narrow the check (e.g. a specific module or package directory).
+
+### status-options
+
+**Optional.** Additional flags forwarded to `git status` (e.g. `--ignored`, `-u`, `--untracked-files=all`).
+
+## Outputs
+
+### has-changes
+
+`true` if changes are detected in the target path, `false` otherwise.
+Includes both tracked modifications and untracked files.
+
+## Works well with
+
+- [**create-pr**](../create-pr/README.md) — open a pull request only when changes are present.
+- [**run-pint**](../run-pint/README.md) — run code style checks on changed paths.
+- [**run-phpstan**](../run-phpstan/README.md) — run static analysis only when relevant files changed.
+
+## Example
+
+```yaml
+name: Conditional PR on Changes
+
+on:
+    push:
+        branches:
+            - develop
+
+jobs:
+    detect-and-pr:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Detect changes
+              id: changes
+              uses: tomgrv/actions/detect-changes@v1
+              with:
+                  path: src
+                  subpath: components
+                  status-options: '--untracked-files=all'
+
+            - name: Create PR if changes found
+              if: steps.changes.outputs.has-changes == 'true'
+              uses: tomgrv/actions/create-pr@v1
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/detect-changes/action.yml
+++ b/detect-changes/action.yml
@@ -1,0 +1,46 @@
+# @format
+
+# @package tomgrv/actions/detect-changes
+
+name: Detect Changes
+description: Detect uncommitted or untracked changes in a given path using git status.
+author: Perspikapps
+branding:
+  icon: git-commit
+  color: yellow
+
+inputs:
+  path:
+    description: Base path to check for changes (relative to repo root).
+    required: false
+    default: '.'
+  subpath:
+    description: Subpath or glob within the base path to narrow the check.
+    required: false
+    default: ''
+  status-options:
+    description: Additional options passed to `git status` (e.g. --ignored, -u).
+    required: false
+    default: ''
+
+outputs:
+  has-changes:
+    description: "true if changes are detected, false otherwise"
+    value: ${{ steps.detect.outputs.has-changes }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect changes
+      id: detect
+      shell: bash
+      run: |
+        TARGET="${{ inputs.path }}"
+        if [ -n "${{ inputs.subpath }}" ]; then
+          TARGET="$TARGET/${{ inputs.subpath }}"
+        fi
+
+        echo "has-changes=false" >> "$GITHUB_OUTPUT"
+        if [ -n "$(git status --porcelain ${{ inputs.status-options }} -- "$TARGET")" ]; then
+          echo "has-changes=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/detect-changes/action.yml
+++ b/detect-changes/action.yml
@@ -14,18 +14,14 @@ inputs:
     description: Base path to check for changes (relative to repo root).
     required: false
     default: '.'
-  subpath:
-    description: Subpath or glob within the base path to narrow the check.
-    required: false
-    default: ''
-  status-options:
+  options:
     description: Additional options passed to `git status` (e.g. --ignored, -u).
     required: false
     default: ''
 
 outputs:
   has-changes:
-    description: "true if changes are detected, false otherwise"
+    description: 'true if changes are detected, false otherwise'
     value: ${{ steps.detect.outputs.has-changes }}
 
 runs:
@@ -34,4 +30,7 @@ runs:
     - name: Detect changes
       id: detect
       shell: sh
-      run: sh -c "${{ github.action_path }}/run.sh '${{ inputs.path }}' '${{ inputs.subpath }}' '${{ inputs.status-options }}'"
+      env:
+        WORKDIR: ${{ github.path }}
+        OPTIONS: ${{ inputs.options }}
+      run: sh -c "${{ github.action_path }}/run.sh" >> $GITHUB_OUTPUT

--- a/detect-changes/action.yml
+++ b/detect-changes/action.yml
@@ -33,14 +33,5 @@ runs:
   steps:
     - name: Detect changes
       id: detect
-      shell: bash
-      run: |
-        TARGET="${{ inputs.path }}"
-        if [ -n "${{ inputs.subpath }}" ]; then
-          TARGET="$TARGET/${{ inputs.subpath }}"
-        fi
-
-        echo "has-changes=false" >> "$GITHUB_OUTPUT"
-        if [ -n "$(git status --porcelain ${{ inputs.status-options }} -- "$TARGET")" ]; then
-          echo "has-changes=true" >> "$GITHUB_OUTPUT"
-        fi
+      shell: sh
+      run: sh -c "${{ github.action_path }}/run.sh '${{ inputs.path }}' '${{ inputs.subpath }}' '${{ inputs.status-options }}'"

--- a/detect-changes/run.sh
+++ b/detect-changes/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/sh
+
+set -e
+
+if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+  cd "${GITHUB_WORKSPACE}" || exit 1
+  git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
+fi
+
+PATH_ARG="${1:-.}"
+SUBPATH_ARG="${2:-}"
+STATUS_OPTS="${3:-}"
+
+if [ -n "${SUBPATH_ARG}" ]; then
+  TARGET="${PATH_ARG}/${SUBPATH_ARG}"
+else
+  TARGET="${PATH_ARG}"
+fi
+
+echo "Checking for changes in: ${TARGET}" >&2
+
+echo "has-changes=false" >> "${GITHUB_OUTPUT}"
+
+# shellcheck disable=SC2086
+if [ -n "$(git status --porcelain ${STATUS_OPTS} -- "${TARGET}")" ]; then
+  echo "has-changes=true" >> "${GITHUB_OUTPUT}"
+  echo "Changes detected in ${TARGET}" >&2
+fi

--- a/detect-changes/run.sh
+++ b/detect-changes/run.sh
@@ -7,22 +7,16 @@ if [ -n "${GITHUB_WORKSPACE:-}" ]; then
   git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
 fi
 
-PATH_ARG="${1:-.}"
-SUBPATH_ARG="${2:-}"
-STATUS_OPTS="${3:-}"
+WORKDIR="${WORKDIR:-.}"
+OPTIONS="${OPTIONS:-}"
 
-if [ -n "${SUBPATH_ARG}" ]; then
-  TARGET="${PATH_ARG}/${SUBPATH_ARG}"
-else
-  TARGET="${PATH_ARG}"
-fi
 
-echo "Checking for changes in: ${TARGET}" >&2
+echo "Checking for changes in: ${WORKDIR}" >&2
 
 echo "has-changes=false" >> "${GITHUB_OUTPUT}"
 
 # shellcheck disable=SC2086
-if [ -n "$(git status --porcelain ${STATUS_OPTS} -- "${TARGET}")" ]; then
+if [ -n "$(git status --porcelain ${OPTIONS} -- "${WORKDIR}")" ]; then
   echo "has-changes=true" >> "${GITHUB_OUTPUT}"
-  echo "Changes detected in ${TARGET}" >&2
+  echo "Changes detected in ${WORKDIR}" >&2
 fi


### PR DESCRIPTION
### What
Adds a new `detect-changes` composite action that detects uncommitted or untracked changes in a configurable path using `git status --porcelain`.

### Why
Resolves #18. The inline snippet from the issue used `git diff`, but this implementation uses `git status --porcelain` (Option C) to also capture untracked files, giving broader coverage.

### How
- New composite action at `detect-changes/action.yml`, following the existing repo template conventions (`# @format`, `# @package`, `author: Perspikapps`, etc.)
- Three configurable inputs:
  - `path` — base path to check (default: `.`)
  - `subpath` — optional sub-path appended to `path`
  - `status-options` — extra flags forwarded to `git status` (e.g. `--ignored`, `-u`)
- Single output: `has-changes` (`true` / `false`)

**Usage example:**
```yaml
- uses: tomgrv/actions/detect-changes@main
  id: changes
  with:
    path: src
    subpath: components
    status-options: '--ignored'

- if: steps.changes.outputs.has-changes == 'true'
  run: echo "Changes detected!"
```

### Checklist
- [x] Code follows project conventions
- [ ] Tests added or updated
- [x] No breaking changes
- [x] Ready for review